### PR TITLE
New --cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This repo contains both [Singularity]("https://sylabs.io/guides/3.0/user-guide/i
 #### Conda
 The repo contains a environment.yml files which automatically build the correct conda env if `-profile conda` is specifed in the command. Although you'll need `conda` installed, this is probably the easiest way to run this pipeline.
 
+--cache /some/dir can be specified to have a fixed, shared location to store the conda build for use by multiple runs of the workflow.
+
 #### Executors
 By default, the pipeline just runs on the local machine. You can specify `-profile slurm` to use a SLURM cluster. 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,11 +3,13 @@ params {
 
   // Workflow flags
   outdir = './results'
-  cache = ''
 
   // Boilerplate options
   help = false
   tracedir = "${params.outdir}/pipeline_info"
+
+  // cache option makes it a bit easier to set conda or singularity cacheDir
+  cache = ''
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,6 +3,7 @@ params {
 
   // Workflow flags
   outdir = './results'
+  cache = ''
 
   // Boilerplate options
   help = false
@@ -31,6 +32,9 @@ profiles {
      } else if (params.illumina) {
        process.conda = "$baseDir/environment-illumina.yml"
      }
+     if (params.cache){
+       conda.cacheDir = params.cache
+     }
   }
   docker {
     docker.enabled = true
@@ -47,6 +51,9 @@ profiles {
       process.container = "file:///${baseDir}/artic-ncov2019-nanopolish.sif"
     } else if (params.illumina) {
       process.container = "file:///${baseDir}/artic-ncov2019-illumina.sif"
+    }
+    if (params.cache){
+      singularity.cacheDir = params.cache
     }
   }
   slurm {


### PR DESCRIPTION
Conda and singularity cache defaults to being in the work directory.

When you run the work flow many times, each time with a new work directory, it makes sense to have the cache in a central location and only cache once.

This PR makes it a bit easier to specify the cache location on the command line.