### PR TITLE
Add cram input option for illumina workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This Nextflow pipeline automates the ARTIC network [nCoV-2019 novel coronavirus 
 ##### Illumina
 `nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --illumina --prefix "output_file_prefix" --directory /path/to/reads`
 
+You can also use cram file input by passing the --cram flag.
+
 ##### Nanopore
 ###### Nanopolish
 `nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --nanopolish --prefix "output_file_prefix" --basecalled_fastq /path/to/directory --fast5_pass /path/to/directory --sequencing_summary /path/to/sequencing_summary.txt`

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -7,6 +7,9 @@ params {
     fastq_exts = ['.fastq.gz', '.fq.gz']
 
     fastqSearchPath = makeFastqSearchPath( params.illuminaSuffixes, params.fastq_exts )
+    
+    // Use cram input instead of fastq files
+    cram = false
 
     // Allow reads that don't have primer sequence? Ligation prep = false, nextera = true
     allowNoprimer = true

--- a/main.nf
+++ b/main.nf
@@ -38,8 +38,14 @@ if ( ! params.prefix ) {
 // main workflow
 workflow {
    if ( params.illumina ) {
-       Channel.fromFilePairs( params.fastqSearchPath, flat: true)
-              .set{ ch_filePairs }
+       if (params.cram) {
+           Channel.fromPath( "${runDirectory}*.cram" )
+              .set{ ch_cramDirectory }
+       }
+       else {
+	   Channel.fromFilePairs( params.fastqSearchPath, flat: true)
+	       .set{ ch_filePairs }
+       }
    }
    else {
        Channel.fromPath( "${params.basecalled_fastq}" )
@@ -72,8 +78,13 @@ workflow {
      if ( params.nanopolish || params.medaka ) {
          articNcovNanopore(ch_fastqDirs, ch_fast5Pass, ch_seqSummary)
      } else if ( params.illumina ) {
-         ncovIllumina(ch_filePairs)
-    } else {
+         if ( params.cram ) {
+            ncovIlluminaCram(ch_cramDirectory)
+         }
+         else {
+            ncovIllumina(ch_filePairs)
+         }
+     } else {
          println("Please select a workflow with --nanopolish, --illumina or --medaka")
      }
      

--- a/main.nf
+++ b/main.nf
@@ -40,7 +40,7 @@ if ( ! params.prefix ) {
 workflow {
    if ( params.illumina ) {
        if (params.cram) {
-           Channel.fromPath( "${runDirectory}*.cram" )
+           Channel.fromPath( "${params.directory}/**.cram" )
               .set{ ch_cramDirectory }
        }
        else {

--- a/main.nf
+++ b/main.nf
@@ -6,6 +6,7 @@ nextflow.preview.dsl = 2
 // import subworkflows
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
+include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
 
 
 if ( params.illumina ) {

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -173,7 +173,7 @@ process cramToFastq {
         file(cram)
 
     output:
-        tuple(val(${cram.toString().replaceFirst(/\.cram/, "")}), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
+        tuple(val("${cram.toString().replaceFirst(/\.cram/, "")}"), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
 
     script:
         """

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -159,3 +159,27 @@ process makeConsensus {
         """
 }
 
+process cramToFastq {
+    /**
+    * Converts CRAM to fastq (http://bio-bwa.sourceforge.net/)
+    * Uses samtools to convert to CRAM, to FastQ (http://www.htslib.org/doc/samtools.html)
+    * @input
+    * @output
+    */
+
+    //publishDir "${params.outdir}/${task.process.replaceAll(":","_")}"
+
+    input:
+        file(cram)
+
+    output:
+        tuple(val(${cram.toString().replaceFirst(/\.cram/, "")}), path("*_1.fastq.gz"),path("*_2.fastq.gz"))
+
+    script:
+        """
+        samtools collate -u ${cram} -o tmp.bam
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.$
+        rm tmp.bam
+        """
+}
+

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -178,7 +178,7 @@ process cramToFastq {
     script:
         """
         samtools collate -u ${cram} -o tmp.bam
-        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")}
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.bam
         rm tmp.bam
         """
 }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -178,7 +178,7 @@ process cramToFastq {
     script:
         """
         samtools collate -u ${cram} -o tmp.bam
-        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")} tmp.$
+        samtools fastq -1 ${cram.toString().replaceFirst(/\.cram/, "_1.fastq.gz")} -2 ${cram.toString().replaceFirst(/\.cram/, "_2.fastq.gz")}
         rm tmp.bam
         """
 }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -77,3 +77,11 @@ workflow ncovIllumina {
 
 }
 
+workflow ncovIlluminaCram {
+    take:
+      ch_cramDirectory
+    main:
+      cramToFastq(ch_cramDirectory)
+      ncovIllumina(cramToFastq.out)
+}
+

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -21,6 +21,8 @@ include {collateSamples} from '../modules/upload.nf'
 include {CLIMBrsync} from './upload.nf'
 
 
+include {cramToFastq} from '../modules/illumina.nf' params(params)
+
 workflow sequenceAnalysis {
     take:
       ch_filePairs


### PR DESCRIPTION
Some sequencing centres produce unaligned cram files to represent the sequencing data.

This PR converts cram to fastq, then the illumina workflow carries on as normal.