### PR TITLE
Allow use of local scheme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This Nextflow pipeline automates the ARTIC network [nCoV-2019 novel coronavirus 
 
 You can also use cram file input by passing the --cram flag.
 
+For production use at large scale, where you will run the workflow many times, you can avoid cloning the scheme repository, creating an ivar bed file and indexing the reference every time by supplying both --ivarBed /path/to/ivar-compatible.bed and --alignerRefPrefix /path/to/bwa-indexed/ref.fa.
+
+Alternatively you can avoid just the cloning of the scheme repository to remain on a fixed revision of it over time by passing --schemeRepoURL /path/to/own/clone/of/github.com/artic-network/artic-ncov2019. This removes any internet access from the workflow except for the optional upload steps.
+
 ##### Nanopore
 ###### Nanopolish
 `nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --nanopolish --prefix "output_file_prefix" --basecalled_fastq /path/to/directory --fast5_pass /path/to/directory --sequencing_summary /path/to/sequencing_summary.txt`

--- a/conf/base.config
+++ b/conf/base.config
@@ -20,6 +20,19 @@ params{
     // Scheme version
     schemeVersion = 'V2'
 
+    // Instead of creating an ivar-compatible bed file from the bed file in the
+    // scheme repo, the full path to a previously-created ivar bed file. Must
+    // also supply alignerRefPrefix. Only works with illumina workflow.
+    ivarBed = ''
+
+    // Instead of indexing the reference file in the scheme repo, the prefix
+    // of previously-created reference index files. Must also supply ivarBed.
+    // (With these defined, none of the scheme* variables will be used.)
+    alignerRefPrefix = ''
+
+    // Use cram input instead of fastq files
+    cram = false
+
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -20,19 +20,6 @@ params{
     // Scheme version
     schemeVersion = 'V2'
 
-    // Instead of creating an ivar-compatible bed file from the bed file in the
-    // scheme repo, the full path to a previously-created ivar bed file. Must
-    // also supply alignerRefPrefix. Only works with illumina workflow.
-    ivarBed = ''
-
-    // Instead of indexing the reference file in the scheme repo, the prefix
-    // of previously-created reference index files. Must also supply ivarBed.
-    // (With these defined, none of the scheme* variables will be used.)
-    alignerRefPrefix = ''
-
-    // Use cram input instead of fastq files
-    cram = false
-
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false
 

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -2,6 +2,16 @@
 
 params {
 
+    // Instead of using the ivar-compatible bed file in the scheme repo, the
+    // full path to a previously-created ivar bed file. Must also supply
+    // alignerRefPrefix.
+    ivarBed = ''
+
+    // Instead of indexing the reference file in the scheme repo, the prefix
+    // of previously-created reference index files. Must also supply ivarBed.
+    // (With these defined, none of the scheme* variables will be used.)
+    alignerRefPrefix = ''
+
     // illumina fastq search path
     illuminaSuffixes = ['*_R{1,2}_001', '*_R{1,2}', '*_{1,2}' ]
     fastq_exts = ['.fastq.gz', '.fq.gz']

--- a/main.nf
+++ b/main.nf
@@ -14,6 +14,10 @@ if ( params.illumina ) {
        println("Please supply a directory containing fastqs with --directory")
        System.exit(1)
    }
+   if ( params.ivarBed && ! params.alignerRefPrefix ) {
+       println("ivarBed and alignerRefPrefix must be supplied together")
+       System.exit(1)
+   }
 } else if ( params.medaka || params.nanopolish ) {
    if (! params.basecalled_fastq ) {
        println("Please supply a directory containing basecalled fastqs with --basecalled_fastq (this is the output directory from guppy_barcoder or guppy_basecaller)")
@@ -23,6 +27,10 @@ if ( params.illumina ) {
    }
    if (! params.sequencing_summary ) {
        println("Please supply the path to the sequencing_summary.txt file from your run with --sequencing_summary")
+       System.exit(1)
+   }
+   if ( params.ivarBed || params.alignerRefPrefix ) {
+       println("ivarBed and alignerRefPrefix only work in illumina mode")
        System.exit(1)
    }
 } else {

--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,7 @@ if ( params.illumina ) {
        println("Please supply a directory containing fastqs with --directory")
        System.exit(1)
    }
-   if ( params.ivarBed && ! params.alignerRefPrefix ) {
+   if ( (params.ivarBed && ! params.alignerRefPrefix) || (!params.ivarBed && params.alignerRefPrefix) ) {
        println("ivarBed and alignerRefPrefix must be supplied together")
        System.exit(1)
    }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -32,17 +32,17 @@ process indexReference {
     * Indexes reference fasta file in the scheme repo using bwa.
     */
 
-    tag { schemeRepo }
+    tag { ref }
 
     input:
-        path(schemeRepo)
+        path(ref)
 
     output:
         tuple(path('ref.fa'), path('ref.fa.amb'), path('ref.fa.ann'), path('ref.fa.bwt'), path('ref.fa.pac'), path('ref.fa.sa'))
 
     script:
         """
-        ln -s ${schemeRepo}/${params.schemeDir}/${params.scheme}/${params.schemeVersion}/*.reference.fasta ref.fa
+        ln -s ${ref} ref.fa
         bwa index ref.fa
         """
 }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -6,7 +6,6 @@ nextflow.preview.dsl = 2
 // import modules
 include {articDownloadScheme } from '../modules/artic.nf' 
 include {makeIvarBedfile} from '../modules/illumina.nf' 
-include {cramToFastq} from '../modules/illumina.nf'
 include {readTrimming} from '../modules/illumina.nf' 
 include {indexReference} from '../modules/illumina.nf'
 include {readMapping} from '../modules/illumina.nf' 
@@ -65,10 +64,6 @@ workflow sequenceAnalysis {
 
         callVariants(trimPrimerSequences.out.ptrim.combine(ref))
       }
-
-      trimPrimerSequences(articDownloadScheme.out.bed.combine(readMapping.out))
-
-      callVariants(trimPrimerSequences.out.ptrim.combine(articDownloadScheme.out.reffasta))
 
       makeConsensus(trimPrimerSequences.out.ptrim)
 

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -32,9 +32,18 @@ workflow sequenceAnalysis {
     main:
       readTrimming(ch_filePairs)
 
+      ref = Channel.fromPath("var")
+      if (params.alignerRefPrefix) {
+        ref = Channel.fromPath(params.alignerRefPrefix)
+      } else if (params.schemeRepoURL =~ /^http/) {
+        articDownloadScheme()
+        ref = articDownloadScheme.out.reffasta
+      } else {
+        ref = Channel.fromPath("${params.schemeRepoURL}/**/${params.schemeVersion}/*.reference.fasta")
+      }
+
       if (params.ivarBed != "" && params.alignerRefPrefix != "") {
         ivarBed = Channel.fromPath(params.ivarBed)
-        ref = Channel.fromPath(params.alignerRefPrefix)
         index = Channel.fromPath("${params.alignerRefPrefix}.*")
 
         readMapping(ref.combine(index.collect()).combine(readTrimming.out))
@@ -43,21 +52,18 @@ workflow sequenceAnalysis {
 
         callVariants(trimPrimerSequences.out.ptrim.combine(ref))
       } else {
+        indexReference(ref)
+
+        readMapping(indexReference.out.combine(readTrimming.out))
+
         if (params.schemeRepoURL =~ /^http/) {
-          articDownloadScheme()
-          indexReference(articDownloadScheme.out)
-          readMapping(indexReference.out.combine(readTrimming.out))
           trimPrimerSequences(articDownloadScheme.out.bed.combine(readMapping.out))
-          callVariants(trimPrimerSequences.out.ptrim.combine(articDownloadScheme.out.reffasta))
         } else {
-          localScheme = Channel.fromPath(params.schemeRepoURL)
-          indexReference(localScheme)
-          readMapping(indexReference.out.combine(readTrimming.out))
           localBed = Channel.fromPath("${params.schemeRepoURL}/**/${params.schemeVersion}/${params.scheme}.bed")
           trimPrimerSequences(localBed.combine(readMapping.out))
-          localRef = Channel.fromPath("${params.schemeRepoURL}/**/${params.schemeVersion}/*.reference.fasta")
-          callVariants(trimPrimerSequences.out.ptrim.combine(localRef))
-        } 
+        }
+
+        callVariants(trimPrimerSequences.out.ptrim.combine(ref))
       }
 
       trimPrimerSequences(articDownloadScheme.out.bed.combine(readMapping.out))
@@ -67,7 +73,7 @@ workflow sequenceAnalysis {
       makeConsensus(trimPrimerSequences.out.ptrim)
 
       makeQCCSV(trimPrimerSequences.out.ptrim.join(makeConsensus.out, by: 0)
-                                   .combine(articDownloadScheme.out.reffasta))
+                                   .combine(ref))
 
       makeQCCSV.out.csv.splitCsv()
                        .unique()

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -28,11 +28,17 @@ workflow sequenceAnalysis {
       ch_filePairs
 
     main:
-      articDownloadScheme()
-
-      readTrimming(ch_filePairs)
-
-      readMapping(articDownloadScheme.out.scheme.combine(readTrimming.out))
+      if (params.schemeRepoURL =~ /^http/) {
+        articDownloadScheme()
+        makeIvarBedfile(articDownloadScheme.out)
+        readTrimming(ch_filePairs)
+        readMapping(articDownloadScheme.out.combine(readTrimming.out))
+      } else {
+        localScheme = Channel.fromPath(params.schemeRepoURL)
+        makeIvarBedfile(localScheme)
+        readTrimming(ch_filePairs)
+        readMapping(localScheme.combine(readTrimming.out))
+      }
 
       trimPrimerSequences(articDownloadScheme.out.bed.combine(readMapping.out))
 

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -6,6 +6,7 @@ nextflow.preview.dsl = 2
 // import modules
 include {articDownloadScheme } from '../modules/artic.nf' 
 include {makeIvarBedfile} from '../modules/illumina.nf' 
+include {cramToFastq} from '../modules/illumina.nf'
 include {readTrimming} from '../modules/illumina.nf' 
 include {readMapping} from '../modules/illumina.nf' 
 include {trimPrimerSequences} from '../modules/illumina.nf' 
@@ -30,13 +31,14 @@ workflow sequenceAnalysis {
     main:
       if (params.schemeRepoURL =~ /^http/) {
         articDownloadScheme()
-        makeIvarBedfile(articDownloadScheme.out)
+        makeIvarBedfile(articDownloadScheme.out.scheme)
         readTrimming(ch_filePairs)
-        readMapping(articDownloadScheme.out.combine(readTrimming.out))
+        readMapping(articDownloadScheme.out.scheme.combine(readTrimming.out))
       } else {
-        localScheme = Channel.fromPath(params.schemeRepoURL)
-        makeIvarBedfile(localScheme)
+        localRef = Channel.fromPath("${params.schemeRepoURL}/**/${params.schemeVersion}/*.reference.fasta")
+        makeIvarBedfile(localRef)
         readTrimming(ch_filePairs)
+        localScheme = Channel.fromPath($params.schemeRepoURL)
         readMapping(localScheme.combine(readTrimming.out))
       }
 


### PR DESCRIPTION
In a large scale production environment, it is desirable to minimise the number of steps in the workflow, to avoid internet access, and to avoid re-creation of the same output files for every run of the workflow, which may get run thousands of times.

To this end, this PR enables 2 modes.

In the first, you can supply `--schemeRepoURL /path/to/own/clone/of/github.com/artic-network/artic-ncov2019`. This stops the `git clone` step, and you can run the workflow many times on a known fixed revision of the repo.

In the second, you can supply both `--ivarBed /path/to/ivar-compatible.bed` and `--alignerRefPrefix /path/to/bwa-indexed/ref.fa`. This also stops the reference fasta from being reindexed all the time.