### PR TITLE
Fix prepareReferenceFiles to work when ref not supplied.

### DIFF
--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -50,11 +50,15 @@ workflow prepareReferenceFiles {
 
         ch_refFasta.combine(ch_bwaAuxFiles.collect().toList())
                    .set{ ch_preparedRef }
-        } else {
-            indexReference(ch_refFasta)
-            indexReference.out
-                          .set{ ch_preparedRef }
-        }
+      } else {
+        indexReference(ch_refFasta)
+        indexReference.out
+                      .set{ ch_preparedRef }
+      }
+    } else {
+      indexReference(ch_refFasta)
+      indexReference.out
+                    .set{ ch_preparedRef }
     }
   
     /* If bedfile is supplied, use that,


### PR DESCRIPTION
Thanks @m-bull for your improved implementation of my local changes, but it broke use without supplying ref. This PR fixes it.

BTW, we have CI tests in development that will catch things like this, and we hope you accept the PR and make use of it (which will involve you creating PRs yourself, so the CI can run, before merging only tested code to master).