### PR TITLE
Remove mpileup depth limit in consensus generation

### DIFF
--- a/conf/coguk/sanger.config
+++ b/conf/coguk/sanger.config
@@ -1,4 +1,5 @@
 params.allowNoprimer = false
+params.mpileupDepth = 0
 
 executor {
     $lsf {


### PR DESCRIPTION
The current samtools depth reduction technique is not suitable for the high depth NovaSeq output together with end of amplicon (ligated/tailed) adapters.