### PR TITLE
Add samtools ampliconstats feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The repo contains a environment.yml files which automatically build the correct 
 
 --cache /some/dir can be specified to have a fixed, shared location to store the conda build for use by multiple runs of the workflow.
 
+> For samtools-ampliconstats support commited [here](https://github.com/ac55-sanger/ncov2019-artic-nf/commit/aa127d4e98b3ef3bfe887c789ce03cbf483c34ef), you first need to build the conda packages of htslib and samtools from their development repository using the steps at [conda_samtools_development](https://github.com/ac55-sanger/conda_samtools_development) and modifying the `environment.yml` file as instructed [here](https://github.com/ac55-sanger/conda_samtools_development#install-using-an-environment-file). 
+
 #### Executors
 By default, the pipeline just runs on the local machine. You can specify `-profile slurm` to use a SLURM cluster, or `-profile lsf` to use an LSF cluster. In either case you may need to also use one of the COG-UK institutional config profiles (phw or sanger), or provide queue names to use in your own config file.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This Nextflow pipeline automates the ARTIC network [nCoV-2019 novel coronavirus 
 
 You can also use cram file input by passing the --cram flag.
 You can also specify cram file output by passing the --outCram flag.
+You can also run apliconstats (from samtools development branch) by passing the --ampliconstats flag.
 
 For production use at large scale, where you will run the workflow many times, you can avoid cloning the scheme repository, creating an ivar bed file and indexing the reference every time by supplying both --ivarBed /path/to/ivar-compatible.bed and --alignerRefPrefix /path/to/bwa-indexed/ref.fa.
 

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -48,6 +48,8 @@ params {
     // iVar minimum mapQ to call variant (ivar variants: -q)
     ivarMinVariantQuality = 20
 
+    // Run ampliconstats (samtools development branch)
+    ampliconstats = false
 }
 
 def makeFastqSearchPath ( illuminaSuffixes, fastq_exts ) {

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -102,6 +102,29 @@ process trimPrimerSequences {
         """
 }
 
+process makeAmpliconstats {
+
+    tag { sampleName }
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}/${sampleName}", pattern: "*.stats", mode: 'copy'
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}/${sampleName}", pattern: "*.png", mode: 'copy'
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}/${sampleName}", pattern: "*.gp", mode: 'copy'
+
+    input:
+    tuple sampleName, path(bam), path(bedfile)
+
+    output:
+    tuple sampleName, path("${sampleName}.amp.stats"), emit: ampstats
+    tuple sampleName, path("*.png"), emit: amppng
+    tuple sampleName, path("*.gp"), emit: ampgp
+
+    script:
+        """
+        samtools ampliconstats -@8 -d 1,20,100 ${bedfile} ${bam} > ${sampleName}.amp.stats
+        plot-ampliconstats -size 1200,900 ampliconstatData ${sampleName}.amp.stats
+        """
+}
+
 process callVariants {
 
     tag { sampleName }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -9,6 +9,7 @@ include {readTrimming} from '../modules/illumina.nf'
 include {indexReference} from '../modules/illumina.nf'
 include {readMapping} from '../modules/illumina.nf' 
 include {trimPrimerSequences} from '../modules/illumina.nf' 
+include {makeAmpliconstats} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
 include {makeConsensus} from '../modules/illumina.nf' 
 include {cramToFastq} from '../modules/illumina.nf'
@@ -92,6 +93,8 @@ workflow sequenceAnalysis {
       readMapping(readTrimming.out.combine(ch_preparedRef))
 
       trimPrimerSequences(readMapping.out.combine(ch_bedFile))
+
+      makeAmpliconstats(trimPrimerSequences.out.ptrim.combine(ch_bedFile))
 
       callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] }))     
 

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -94,7 +94,9 @@ workflow sequenceAnalysis {
 
       trimPrimerSequences(readMapping.out.combine(ch_bedFile))
 
-      makeAmpliconstats(trimPrimerSequences.out.ptrim.combine(ch_bedFile))
+      if(params.ampliconstats) {
+        makeAmpliconstats(trimPrimerSequences.out.ptrim.combine(ch_bedFile))
+      }
 
       callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] }))     
 


### PR DESCRIPTION
This feature of samtools is only available in it's development branch, hence it cannot be directly used. I have created a separate repo and updated the info in README.md file on how to build and use conda packages for htslib and samtools from their development branch. 

This pull request also generates ampliconstats per file basis. Will soon add support to run it against all the files in one go. 