### PR TITLE
Add minReadsPerBarcode parameter for Nanopore workflow

### DIFF
--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -18,4 +18,6 @@ params {
     // Output cram instead of bam files
     outCram = false
 
+    // Ignore barcodes having fewer than this number of reads in total
+    minReadsPerBarcode = 100
 }

--- a/main.nf
+++ b/main.nf
@@ -91,8 +91,15 @@ workflow {
             // Yes, barcodes!
             Channel.fromPath( nanoporeBarcodeDirs )
                    .filter( ~/.*barcode[0-9]{1,4}$/ )
-                   .filter{ it.listFiles().size() > 5 }
-                   .set{ ch_fastqDirs }
+                   .filter{ d ->
+                            def count = 0
+                            for (x in d.listFiles()) {
+                                if (x.isFile()) {
+                                    count += x.countFastq()
+                                }
+                            }
+                            count > params.minReadsPerBarcode
+                   }.set{ ch_fastqDirs }
        } else if ( nanoporeNoBarcode ){
             // No, no barcodes
             Channel.fromPath( "${params.basecalled_fastq}", type: 'dir', maxDepth: 1 )

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -41,6 +41,8 @@ def printHelp() {
       --max_length            Maximum read length for artic guppyplex (Default: 700)
       --bwa                   Use BWA for mapping Nanopore reads (Default: false, use Minimap2)
       --outCram               Output cram instead of bam files (Default: false)
+      --minReadsPerBarcode    Minimum number of reads accepted for a single barcode when supplying deplexed Fastq
+                              files as input. Barcodes having fewer reads are ignored. (Default: 100)
  
   Illumina workflow options:
     Mandatory:


### PR DESCRIPTION
The barcode<n*> directories of de-plexed Fastq input are filtered to
exclude any containing fewer than 5 files (guppy makes all of the
barcode directories, whether you used the barcodes or not).

This patch changes the filter to scan the files and count the records
within to 1) avoid excluding barcodes where many reads are in fewer
than 5 files and 2) avoid including barcodes where there are very few
reads in more than 5 files.

This threshold can be changed with the new optional parameter
minReadsPerBarcode, which defaults to 100 reads.

I expect that this default may not be appropriate. It's somewhat arbitrary
as I'm not sure how many reads would be in those 5 files originally
filtered (more than 100, I suspect).