### PR TITLE
Add ampliconstats process for all the files (Samtools development branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This Nextflow pipeline automates the ARTIC network [nCoV-2019 novel coronavirus 
 
 You can also use cram file input by passing the --cram flag.
 You can also specify cram file output by passing the --outCram flag.
+You can also run apliconstats (from samtools development branch) by passing the --ampliconstats flag.
 
 For production use at large scale, where you will run the workflow many times, you can avoid cloning the scheme repository, creating an ivar bed file and indexing the reference every time by supplying both --ivarBed /path/to/ivar-compatible.bed and --alignerRefPrefix /path/to/bwa-indexed/ref.fa.
 
@@ -41,6 +42,8 @@ This repo contains both [Singularity]("https://sylabs.io/guides/3.0/user-guide/i
 The repo contains a environment.yml files which automatically build the correct conda env if `-profile conda` is specifed in the command. Although you'll need `conda` installed, this is probably the easiest way to run this pipeline.
 
 --cache /some/dir can be specified to have a fixed, shared location to store the conda build for use by multiple runs of the workflow.
+
+> For samtools-ampliconstats support commited [here](https://github.com/ac55-sanger/ncov2019-artic-nf/commit/aa127d4e98b3ef3bfe887c789ce03cbf483c34ef), you first need to build the conda packages of htslib and samtools from their development repository using the steps at [conda_samtools_development](https://github.com/ac55-sanger/conda_samtools_development) and modifying the `environment.yml` file as instructed [here](https://github.com/ac55-sanger/conda_samtools_development#install-using-an-environment-file). 
 
 #### Executors
 By default, the pipeline just runs on the local machine. You can specify `-profile slurm` to use a SLURM cluster, or `-profile lsf` to use an LSF cluster. In either case you may need to also use one of the COG-UK institutional config profiles (phw or sanger), or provide queue names to use in your own config file.

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -48,6 +48,8 @@ params {
     // iVar minimum mapQ to call variant (ivar variants: -q)
     ivarMinVariantQuality = 20
 
+    // Run ampliconstats (samtools development branch)
+    ampliconstats = false
 }
 
 def makeFastqSearchPath ( illuminaSuffixes, fastq_exts ) {

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -102,6 +102,28 @@ process trimPrimerSequences {
         """
 }
 
+process makeAmpliconstats {
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "*.stats", mode: 'copy'
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "*.png", mode: 'copy'
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "*.gp", mode: 'copy'
+
+    input:
+    file (ptrim_bams)
+    path(bedfile)
+
+    output:
+    path "nCoV-2019.amp.stats", emit: ampstats
+    path "*.png", emit: amppng
+    path "*.gp", emit: ampgp
+
+    script:
+        """
+        samtools ampliconstats -@8 -d 1,20,100 ${bedfile} *.mapped.primertrimmed.sorted.bam > nCoV-2019.amp.stats
+        plot-ampliconstats -size 1200,900 nCoV-2019-ampliconstats nCoV-2019.amp.stats
+        """
+}
+
 process callVariants {
 
     tag { sampleName }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -9,6 +9,7 @@ include {readTrimming} from '../modules/illumina.nf'
 include {indexReference} from '../modules/illumina.nf'
 include {readMapping} from '../modules/illumina.nf' 
 include {trimPrimerSequences} from '../modules/illumina.nf' 
+include {makeAmpliconstats} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
 include {makeConsensus} from '../modules/illumina.nf' 
 include {cramToFastq} from '../modules/illumina.nf'
@@ -119,6 +120,15 @@ workflow sequenceAnalysis {
         bamToCram(qc.pass.map{ it[0] } 
                         .join (trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] })) )
 
+      }
+
+      // Generate ampliconstats only if --ampliconstats parameter is passed
+      if(params.ampliconstats) {
+        // Create a channel to collect only the mapped.primertrimmed.sorted.bam output files from trimPrimerSequences
+
+        trimPrimerSequences.out.ptrim.map{sample, bam -> bam}.collect().set{ ch_ptrim_bam }
+        
+        makeAmpliconstats(ch_ptrim_bam, ch_bedFile)
       }
 
     emit:


### PR DESCRIPTION
This feature of samtools is only available in it's development branch, hence it cannot be directly used. 
I have created a separate repo and updated the info in README.md file on how to build and use conda packages for htslib and samtools from their development branch.
OR
samtools entry can be removed from the enviroment.yml file and have the development branch installed manually.

This pull request generates ampliconstats on all the files in one go (as intended) by passing --ampliconstats flag to nextflow run command.