### PR TITLE
use ivar default of 30 for illuminaKeepLen in Sanger config

### DIFF
--- a/conf/coguk/sanger.config
+++ b/conf/coguk/sanger.config
@@ -1,4 +1,7 @@
+// params for seqeuncing libraries ligating/tailing adapters to amplicon
 params.allowNoprimer = false
+params.illuminaKeepLen = 30  // ivar default (or higher good for this library type)
+// samtools <=1.10 mpileup does not limit depth well (for high depth, common read start locii)
 params.mpileupDepth = 0
 
 executor {


### PR DESCRIPTION
This is more appropriate for libraries created by ligating adapters on the end of the amplicon (than when tagmentation is used as with many other Illumina pipelines)