### PR TITLE
Fix up how samples are searched for using fileglobs

### DIFF
--- a/.github/scripts/test_PR_against_release.sh
+++ b/.github/scripts/test_PR_against_release.sh
@@ -17,38 +17,38 @@ cp -r results results_singularity_profile
 cp -r work work_singularity_profile
 
 # run tests against previous previous_release to compare outputs 
-#git clone https://github.com/connor-lab/ncov2019-artic-nf.git previous_release 
-#cd previous_release
-#git checkout 5e00ba938d9e9f903a8da381a87eaff874e09802 
+git clone https://github.com/connor-lab/ncov2019-artic-nf.git previous_release 
+cd previous_release
+git checkout tags/v1.0.0 
 
 # the github runner only has 2 cpus available, so replace for that commit required:
-#sed -i s'/cpus = 4/cpus = 2/'g conf/resources.config
-#ln -s ../*.sif ./
-#echo Nextflow run previous release in --illumina mode.. >> ../artifacts/test_artifact.log
-#NXF_VER=20.03.0-edge nextflow run ./main.nf \
-#       -profile singularity \
-#       --directory $PWD/../.github/data/fastqs/ \
-#       --illumina \
-#       --prefix test
-#cp .nextflow.log ../artifacts/previous_release.nextflow.log
-#cd ..
-#
+sed -i s'/cpus = 4/cpus = 2/'g conf/resources.config
+ln -s ../*.sif ./
+echo Nextflow run previous release in --illumina mode.. >> ../artifacts/test_artifact.log
+NXF_VER=20.03.0-edge nextflow run ./main.nf \
+       -profile singularity \
+       --directory $PWD/../.github/data/fastqs/ \
+       --illumina \
+       --prefix test
+cp .nextflow.log ../artifacts/previous_release.nextflow.log
+cd ..
+
 ## exclude files from comparison
 ## and list differences
-#echo Compare ouputs of current PR vs those of previous release.. >> artifacts/test_artifact.log
-#find results ./previous_release/results \
-#     -name "test.qc.csv" \
-#     -o -name "*.fq.gz" \
-#     -o -name "*.bam" \
-#     -o -name "scheme" | xargs rm -rf
-#if ! git diff --stat --no-index results ./previous_release/results > diffs.txt ; then
-#  echo "test failed: differences found between PR and previous release" >> artifacts/test_artifact.log
-#  echo see diffs.txt >> artifacts/test_artifact.log 
-#  cp diffs.txt artifacts/
-#  exit 1
-#else
-#  echo no differences found between PR and previous release >> artifacts/test_artifact.log
-#fi
-#
+echo Compare ouputs of current PR vs those of previous release.. >> artifacts/test_artifact.log
+find results ./previous_release/results \
+     -name "test.qc.csv" \
+     -o -name "*.fq.gz" \
+     -o -name "*.bam" \
+     -o -name "scheme" | xargs rm -rf
+if ! git diff --stat --no-index results ./previous_release/results > diffs.txt ; then
+  echo "test failed: differences found between PR and previous release" >> artifacts/test_artifact.log
+  echo see diffs.txt >> artifacts/test_artifact.log 
+  cp diffs.txt artifacts/
+  exit 1
+else
+  echo no differences found between PR and previous release >> artifacts/test_artifact.log
+fi
+
 ## clean-up for following tests
 rm -rf previous_release && rm -rf results && rm -rf work && rm -rf .nextflow*

--- a/conf/coguk/phw.config
+++ b/conf/coguk/phw.config
@@ -2,6 +2,8 @@
 
 params {
     cleanBamHeader = true
+
+    illuminaPrefixes = ['SARS-']
 }
 
 process {

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -12,12 +12,13 @@ params {
     // (With these defined, none of the scheme* variables will be used.)
     ref = false
 
+    // Illumina sample prefixes - list of strings that prefix samples
+    illuminaPrefixes = false
+
     // illumina fastq search path
     illuminaSuffixes = ['*_R{1,2}_001', '*_R{1,2}', '*_{1,2}' ]
     fastq_exts = ['.fastq.gz', '.fq.gz']
 
-    fastqSearchPath = makeFastqSearchPath( params.illuminaSuffixes, params.fastq_exts )
-    
     // Use cram input instead of fastq files
     cram = false
     
@@ -51,22 +52,5 @@ params {
     // iVar minimum mapQ to call variant (ivar variants: -q)
     ivarMinVariantQuality = 20
 
-}
-
-def makeFastqSearchPath ( illuminaSuffixes, fastq_exts ) {
-    //if (! params.directory ) {
-    //    println("Please supply a directory containing fastqs with --directory")
-    //    System.exit(1)
-    //}
-
-    if ( params.directory ) {
-      def fastq_searchpath = []
-      for (item in illuminaSuffixes){
-          for(thing in fastq_exts){
-              fastq_searchpath.add(params.directory.toString() + '/**' + item.toString() + thing.toString())
-          }
-      }
-      return fastq_searchpath
-    }
 }
 

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,8 @@
 nextflow.preview.dsl = 2
 
 // include modules
-include printHelp from './modules/help.nf'
+include {printHelp} from './modules/help.nf'
+include {makeFastqSearchPath} from './modules/util.nf'
 
 // import subworkflows
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
@@ -78,7 +79,9 @@ workflow {
                   .set{ ch_cramFiles }
        }
        else {
-	   Channel.fromFilePairs( params.fastqSearchPath, flat: true)
+           fastqSearchPath = makeFastqSearchPath( params.illuminaPrefixes, params.illuminaSuffixes, params.fastq_exts )
+
+	   Channel.fromFilePairs( fastqSearchPath, flat: true)
 	          .filter{ !( it[0] =~ /Undetermined/ ) }
 	          .set{ ch_filePairs }
        }

--- a/modules/util.nf
+++ b/modules/util.nf
@@ -1,0 +1,41 @@
+import java.nio.file.Paths
+
+def makeFastqSearchPath ( illuminaPrefixes, illuminaSuffixes, fastq_exts ) {
+
+    def fastqSearchPath = []
+
+    for (suff in illuminaSuffixes){
+        for(ext in fastq_exts){
+          if ( illuminaPrefixes ) {
+            for (prefix in illuminaPrefixes) {
+              
+              // Make a glob to recurse directories
+              dirNameGlob = params.directory + '**'
+ 
+              // Make a filename glob
+              fileNameGlob = prefix + suff + ext
+
+              // Build a path
+              searchPath = Paths.get(dirNameGlob, fileNameGlob )
+
+              fastqSearchPath.add(searchPath.toString())
+              }
+          } else {
+
+              // Make a glob to recurse directories
+              dirNameGlob = params.directory + '**'
+
+              // Make a glob for filenames
+              fileNameGlob = suff + ext
+
+              // Build a path
+              searchPath = Paths.get(dirNameGlob, fileNameGlob)
+
+              fastqSearchPath.add(searchPath.toString())
+          }
+        }
+    }
+
+    return fastqSearchPath
+}
+

--- a/modules/util.nf
+++ b/modules/util.nf
@@ -10,7 +10,7 @@ def makeFastqSearchPath ( illuminaPrefixes, illuminaSuffixes, fastq_exts ) {
             for (prefix in illuminaPrefixes) {
               
               // Make a glob to recurse directories
-              dirNameGlob = params.directory + '**'
+              dirNameGlob = params.directory.replaceAll(/\/+$/, "") + '**'
  
               // Make a filename glob
               fileNameGlob = prefix + suff + ext
@@ -23,7 +23,7 @@ def makeFastqSearchPath ( illuminaPrefixes, illuminaSuffixes, fastq_exts ) {
           } else {
 
               // Make a glob to recurse directories
-              dirNameGlob = params.directory + '**'
+              dirNameGlob = params.directory.replaceAll(/\/+$/, "") + '**'
 
               // Make a glob for filenames
               fileNameGlob = suff + ext


### PR DESCRIPTION
Old method was some horrible string concatenation thing, so replace with proper path joining and move out into a module/function. This is handy for finding SARS-CoV-2 samples on mixed sequencing runs by specifying a (list of) prefix strings that identify target samples.