### PR TITLE
Switch to multistage builds for Docker and Singularity

### DIFF
--- a/environments/illumina/Dockerfile
+++ b/environments/illumina/Dockerfile
@@ -1,10 +1,17 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:latest AS condabuild
 LABEL authors="Matt Bull" \
       description="Docker image containing all requirements for an Illumina ncov2019 pipeline"
 
 COPY environments/extras.yml /extras.yml
 COPY environments/illumina/environment.yml /environment.yml
-RUN apt-get update && apt-get install -y curl g++ git make procps && apt-get clean -y
-RUN /opt/conda/bin/conda env create -f /environment.yml 
-RUN /opt/conda/bin/conda env update -f /extras.yml -n artic-ncov2019-illumina && /opt/conda/bin/conda clean -a
+RUN /opt/conda/bin/conda update conda && \
+/opt/conda/bin/conda install mamba -c conda-forge && \
+/opt/conda/bin/mamba env create -f /environment.yml && \
+/opt/conda/bin/mamba env update -f /extras.yml -n artic-ncov2019-illumina
+
+FROM debian:buster-slim
+RUN apt-get update && \
+apt-get install -y git procps && \
+apt-get clean -y 
+COPY --from=condabuild /opt/conda/envs/artic-ncov2019-illumina /opt/conda/envs/artic-ncov2019-illumina
 ENV PATH=/opt/conda/envs/artic-ncov2019-illumina/bin:$PATH

--- a/environments/illumina/Singularity
+++ b/environments/illumina/Singularity
@@ -1,5 +1,6 @@
 Bootstrap: docker
 From: continuumio/miniconda3:latest
+Stage: condabuild
 %files
 environments/illumina/environment.yml /environment.yml
 environments/extras.yml /extras.yml
@@ -8,13 +9,22 @@ authors="Matt Bull"
 description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
 %post
 
-apt-get update && apt-get install -y g++ git make procps rsync && apt-get clean -y
-/opt/conda/bin/conda update conda
-/opt/conda/bin/conda install mamba -c conda-forge
-/opt/conda/bin/mamba env create -f /environment.yml
+/opt/conda/bin/conda install mamba -c conda-forge && \
+/opt/conda/bin/mamba env create -f /environment.yml && \
 /opt/conda/bin/mamba env update -f /extras.yml -n artic-ncov2019-illumina
-/opt/conda/bin/mamba clean -a
-PATH=/opt/conda/envs/artic-ncov2019-illumina/bin:$PATH
+
+
+Bootstrap: docker
+From: debian:buster-slim
+Stage: final
+
+%post
+apt-get update && \
+apt-get install -y git procps && \
+apt-get clean -y
+
+%files from condabuild
+  /opt/conda/envs/artic-ncov2019-illumina /opt/conda/envs/artic-ncov2019-illumina
 
 %environment
 export PATH=/opt/conda/envs/artic-ncov2019-illumina/bin:$PATH

--- a/environments/nanopore/Dockerfile
+++ b/environments/nanopore/Dockerfile
@@ -1,11 +1,17 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:latest AS condabuild
 LABEL authors="Matt Bull" \
       description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
 
 COPY environments/extras.yml /extras.yml
-RUN apt-get update && apt-get install -y curl g++ git make procps && apt-get clean -y
-RUN curl -o /environment.yml -fsSL 'https://raw.githubusercontent.com/artic-network/artic-ncov2019/master/environment.yml'
-RUN /opt/conda/bin/conda env create -f /environment.yml
-RUN /opt/conda/bin/conda env update -f /extras.yml -n artic-ncov2019
-ENV PATH /opt/conda/envs/artic-ncov2019/bin:$PATH
-ENTRYPOINT ["/opt/conda/envs/artic-ncov2019/bin/artic"]
+COPY environments/nanopore/environment.yml /environment.yml
+RUN /opt/conda/bin/conda install mamba -c conda-forge && \
+/opt/conda/bin/mamba env create -f /environment.yml && \
+/opt/conda/bin/mamba env update -f /extras.yml -n artic
+
+FROM debian:buster-slim
+RUN apt-get update && \
+apt-get install -y git procps && \
+apt-get clean -y
+COPY --from=condabuild /opt/conda/envs/artic /opt/conda/envs/artic
+ENV PATH=/opt/conda/envs/artic/bin:$PATH
+ENTRYPOINT ["/opt/conda/envs/artic/bin/artic"]

--- a/environments/nanopore/Singularity
+++ b/environments/nanopore/Singularity
@@ -1,25 +1,34 @@
 Bootstrap: docker
 From: continuumio/miniconda3:latest
-%labels
-authors="Matt Bull" 
-description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
+Stage: condabuild
 %files
 environments/nanopore/environment.yml /environment.yml
 environments/extras.yml /extras.yml
-%post
 
-apt-get update && apt-get install -y curl g++ git make procps rsync && apt-get clean -y
-/opt/conda/bin/conda update conda
-/opt/conda/bin/conda install mamba -c conda-forge
-/opt/conda/bin/mamba env create -f /environment.yml
+%labels
+authors="Matt Bull" 
+description="Docker image containing all requirements for the ARTIC project's ncov2019 pipeline"
+
+%post
+/opt/conda/bin/conda install mamba -c conda-forge && \
+/opt/conda/bin/mamba env create -f /environment.yml && \
 /opt/conda/bin/mamba env update -f /extras.yml -n artic
-/opt/conda/bin/mamba clean -a
-PATH=/opt/conda/envs/artic/bin:$PATH
+
+Bootstrap: docker
+From: debian:buster-slim
+Stage: final
+
+%post
+apt-get update && \
+apt-get install -y git procps && \
+apt-get clean -y
+
+%files from condabuild
+  /opt/conda/envs/artic /opt/conda/envs/artic
 
 %environment
 export PATH=/opt/conda/envs/artic/bin:$PATH
 
 %runscript
-
 exec "/opt/conda/envs/artic/bin/artic" "$@"
 


### PR DESCRIPTION
Big savings on final image size - ~30% in Singularity images and ~50% in Docker images. Also harmonises the builds between Singularity and Docker files. Prep for pulling images from dockerhub automagically.