### PR TITLE
fix: update to artic 1.2.2

### DIFF
--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -4,5 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - artic=1.1.3
+  - artic=1.2.2
   - pyyaml=5.3.1


### PR DESCRIPTION
The version `muscle` used in artic was set to  `>=3.8`. As `muscle` published version 5.1, the newer version is now used.
However, the 5.1 version has a different clit which breaks `artic` and thus `ncov2019-artic-nf`:

```bash
Running: muscle -in some.muscle.in.fasta -out some.muscle.out.fasta

Invalid command line
Unknown option in
```

This PR updates the artic version, which includes a bug fix for the problem described above.

See https://github.com/artic-network/fieldbioinformatics/issues/105 for more information.