### PR TITLE
Enable medaka to run V4 primer scheme

### DIFF
--- a/conf/nanopore.config
+++ b/conf/nanopore.config
@@ -29,5 +29,9 @@ params {
 
     // Minimum coverage depth to call aa consequences of variant.
     csqDpThreshold = 20
- 
+
+    // medaka model used by artic minion
+    // {pore}_{device}_{caller variant}_{caller version}
+    medakaModel = 'r941_min_high_g351'
+
 }

--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -4,5 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - artic=1.1.3
+  - artic=1.2.2
   - pyyaml=5.3.1

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -81,6 +81,7 @@ process articMinIONMedaka {
     """
     artic minion --medaka \
     ${minionFinalConfig} \
+    --medaka-model ${params.medakaModel} \
     --threads ${task.cpus} \
     --scheme-directory ${schemeRepo} \
     --read-file ${fastq} \


### PR DESCRIPTION
Changes:

- update artic to 1.2.2
- set up medaka model as this is required for artic 1.2.2. This is configurable. Default is the same as in the artic repo.